### PR TITLE
switch JSON backend from JSON.pm to JSON::MaybeXS

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -32,5 +32,6 @@ DBIx::Class = 0
 Test::More = 0
 Test::Exception = 0
 DBD::SQLite = 0
-JSON = 0
+JSON::MaybeXS = 1.002005
 YAML = 0
+namespace::clean = 0

--- a/lib/DBIx/Class/InflateColumn/Serializer/JSON.pm
+++ b/lib/DBIx/Class/InflateColumn/Serializer/JSON.pm
@@ -35,8 +35,9 @@ The data structures you assign to "data_column" will be saved in the database in
 
 use strict;
 use warnings;
-use JSON qw//;
+use JSON::MaybeXS;
 use Carp;
+use namespace::clean;
 
 =over 4
 
@@ -53,13 +54,13 @@ sub get_freezer{
   if (defined $info->{'size'}){
       my $size = $info->{'size'};
       return sub {
-        my $s = JSON::to_json(shift);
+        my $s = JSON::MaybeXS->new(utf8 => 0)->encode(shift);
         croak "serialization too big" if (length($s) > $size);
         return $s;
       };
   } else {
       return sub {
-        return JSON::to_json(shift);
+        return JSON::MaybeXS->new(utf8 => 0)->encode(shift);
       };
   }
 }
@@ -75,7 +76,7 @@ the data stored in the column. Returns a coderef.
 
 sub get_unfreezer {
   return sub {
-    return JSON::from_json(shift);
+    return JSON::MaybeXS->new(utf8 => 0)->decode(shift);
   };
 }
 

--- a/t/003_json.t
+++ b/t/003_json.t
@@ -6,9 +6,6 @@ use Test::Exception;
 use lib qw(t/lib);
 use DBICTest;
 
-#eval { require JSON::Any };
-#plan( skip_all => 'JSON::Any not installed; skipping' ) if $@;
-
 my $schema = DBICTest->init_schema();
 
 plan tests => 9;


### PR DESCRIPTION
This change also fixes the lack of utf8 support in encoding by using the
encode_json interface, which uses utf8 => 1.

JSON.pm only supports JSON::PP and JSON::XS, whereas there is another very
popular backend now, Cpanel::JSON::XS.
