### PR TITLE
Further improve unicode/character string tests

### DIFF
--- a/t/002_storable.t
+++ b/t/002_storable.t
@@ -6,6 +6,11 @@ use Test::Exception;
 use lib qw(t/lib);
 use DBICTest;
 
+my $builder = Test::More->builder;
+binmode $builder->output,         ":encoding(utf8)";
+binmode $builder->failure_output, ":encoding(utf8)";
+binmode $builder->todo_output,    ":encoding(utf8)";
+
 #eval { require Storable };
 #plan( skip_all => 'Storable not installed; skipping' ) if $@;
 
@@ -28,6 +33,8 @@ my $struct_array = [
         c => 2
     },
     'd',
+    house => 'château',
+    heart => "\x{2764}",
 ];
 
 my $rs = $schema->resultset("SerializeStorable");


### PR DESCRIPTION
Hi there! This is my CPAN PR challenge submission for April 2016 :-)

------------------

I noticed that the test string for unicode in 003_json.t was "château",
which as a latin1 valid string risks interacting with The Unicode Bug
from earlier versions of Perl. Using a string which can only be
represented with utf8 ensures that Perl's unicode systme is being tested
on older Perls. My favourite is \x{2764} also known as HEAVY BLACK HEART.

Also added the same unicode tests to the Storable and YAML test cases.
We can't test the in-DB representation match for Storable of course, but
the end to end test is still useful.

-------------

With perlbrew I tested this change on a bunch of Perls...

    $ perlbrew exec 'prove -lr t 2>&1 | grep ^Result'
    perl-5.10.1
    ==========
    Result: PASS

    perl-5.12.5
    ==========
    Result: PASS

    perl-5.14.4
    ==========
    Result: PASS

    perl-5.16.3
    ==========
    Result: PASS

    perl-5.18.4
    ==========
    Result: PASS

    perl-5.20.2
    ==========
    Result: PASS

    perl-5.22.1
    ==========
    Result: PASS
