### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: perl
+
+perl:
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+
+install:
+    - cpanm Dist::Zilla
+    - dzil authordeps --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
This allows the project to be automatically built and tested with the latest version of Perl on the [Travis-CI](https://travis-ci.org) continuous integration service.