### PR TITLE
Declare minimum Perl version explicitly

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,6 +26,7 @@ allow_dirty = README
 -remove = Readme
 
 [Prereqs]
+perl = 5.8.0
 DBIx::Class = 0
 
 [Prereqs / TestRequires ]


### PR DESCRIPTION
This addresses the CPANTS "meta_yml_declares_perl_version" extra metric
issue.  See http://cpants.cpanauthors.org/dist/DBIx-Class-InflateColumn-Serializer for more info.