### PR TITLE
Move prereqs into correct dist.ini section

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,11 +27,11 @@ allow_dirty = README
 
 [Prereqs]
 DBIx::Class = 0
+JSON::MaybeXS = 1.002005
+YAML = 0
+namespace::clean = 0
 
 [Prereqs / TestRequires ]
 Test::More = 0
 Test::Exception = 0
 DBD::SQLite = 0
-JSON::MaybeXS = 1.002005
-YAML = 0
-namespace::clean = 0


### PR DESCRIPTION
It turns out that JSON::MaybeXS, YAML and namespace::clean are needed
not only as test prerequisites, but also as prerequisites for the dist
itself.  This change updates the dist.ini accordingly meaning ensures
that the correct prereqs are set in the META.yml file.  This change also
fixes the CPANTS "prereq_matches_use" core metric issue.