### PR TITLE
Create a META.json file when building the dist

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ bugs = 0
 [NextRelease]
 [ReadmeFromPod]
 [CopyReadmeFromBuild]
+[MetaJSON]
 
 [@Git]
 allow_dirty = dist.ini


### PR DESCRIPTION
The META.json file is supposed to replace the META.yml file at some
point in the future, hence its addition to the dist future-proofs the
dist a bit.  The change also addresses the "has_meta_json" extra metric
issue found on CPANTS.