### PR TITLE
Add package provides info to dist META info files

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -15,6 +15,7 @@ bugs = 0
 [NextRelease]
 [ReadmeFromPod]
 [CopyReadmeFromBuild]
+[MetaProvides::Package]
 
 [@Git]
 allow_dirty = dist.ini


### PR DESCRIPTION
Although this is considered an experimental issue, it seems to be
considered a good idea to include information about what packages the
dist provides.  This can help downstream services such as MetaCPAN
display more information about the dist.