### PR TITLE
Add strict and warnings pragmas in test files

### DIFF
--- a/t/001_load.t
+++ b/t/001_load.t
@@ -2,6 +2,9 @@
 
 # t/001_load.t - check module loading and create testing directory
 
+use strict;
+use warnings;
+
 use Test::More tests => 1;
 
 BEGIN { 

--- a/t/lib/DBICTest/Schema.pm
+++ b/t/lib/DBICTest/Schema.pm
@@ -1,6 +1,9 @@
 package # hide from PAUSE
     DBICTest::Schema;
 
+use strict;
+use warnings;
+
 use base qw/DBIx::Class::Schema/;
 
 no warnings qw/qw/;

--- a/t/lib/DBICTest/Schema/SerializeJSON.pm
+++ b/t/lib/DBICTest/Schema/SerializeJSON.pm
@@ -1,6 +1,9 @@
 package # hide from PAUSE
     DBICTest::Schema::SerializeJSON;
 
+use strict;
+use warnings;
+
 use base qw/DBIx::Class/;
 
 __PACKAGE__->load_components (qw/InflateColumn::Serializer Core/);

--- a/t/lib/DBICTest/Schema/SerializeStorable.pm
+++ b/t/lib/DBICTest/Schema/SerializeStorable.pm
@@ -1,6 +1,9 @@
 package # hide from PAUSE
     DBICTest::Schema::SerializeStorable;
 
+use strict;
+use warnings;
+
 use base qw/DBIx::Class/;
 
 __PACKAGE__->load_components (qw/InflateColumn::Serializer Core/);

--- a/t/lib/DBICTest/Schema/SerializeYAML.pm
+++ b/t/lib/DBICTest/Schema/SerializeYAML.pm
@@ -1,6 +1,9 @@
 package # hide from PAUSE
     DBICTest::Schema::SerializeYAML;
 
+use strict;
+use warnings;
+
 use base qw/DBIx::Class/;
 
 __PACKAGE__->load_components (qw/InflateColumn::Serializer Core/);

--- a/t/lib/DBICTest/Schema/TestTable.pm
+++ b/t/lib/DBICTest/Schema/TestTable.pm
@@ -1,6 +1,9 @@
 package # hide from PAUSE
     DBICTest::Schema::TestTable;
 
+use strict;
+use warnings;
+
 use base qw/DBIx::Class/;
 
 __PACKAGE__->load_components (qw/Core/);

--- a/xt/kwalitee.t
+++ b/xt/kwalitee.t
@@ -1,4 +1,6 @@
-# in a separate test file
+use strict;
+use warnings;
+
 use Test::More;
 
 eval { require Test::Kwalitee; Test::Kwalitee->import() };

--- a/xt/pod.t
+++ b/xt/pod.t
@@ -1,5 +1,8 @@
 # -*- perl -*-
 
+use strict;
+use warnings;
+
 use Test::More;
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;

--- a/xt/podcoverage.t
+++ b/xt/podcoverage.t
@@ -1,5 +1,8 @@
 # -*- perl -*-
 
+use strict;
+use warnings;
+
 use Test::More;
 eval "use Test::Pod::Coverage 1.00";
 plan skip_all => "Test::Pod::Coverage 1.00 required for testing POD coverage" if $@;


### PR DESCRIPTION
Although these pragmas aren't strictly necessary in the test files
changed here, it's considered best practice to use them in all files.