### PR TITLE
Replace bareword filehandle with lexical variable

### DIFF
--- a/t/lib/DBICTest.pm
+++ b/t/lib/DBICTest.pm
@@ -82,10 +82,10 @@ sub deploy_schema {
     if ($ENV{"DBICTEST_SQLT_DEPLOY"}) { 
         $schema->deploy($args);    
     } else {
-        open IN, "t/lib/sqlite.sql";
+        open my $input, "<", "t/lib/sqlite.sql";
         my $sql;
-        { local $/ = undef; $sql = <IN>; }
-        close IN;
+        { local $/ = undef; $sql = <$input>; }
+        close $input;
         for my $chunk ( split (/;\s*\n+/, $sql) ) {
           if ( $chunk =~ / ^ (?! --\s* ) \S /xm ) {  # there is some real sql in the chunk - a non-space at the start of the string which is not a comment
             $schema->storage->dbh->do($chunk) or print "Error on SQL: $chunk\n";


### PR DESCRIPTION
Bareword filehandles are no longer considered good practice.  One can
use a lexical variable instead to achieve the same purpose, which is the
change which has been implemented here.  The `open` statement also used
the older two-argument form; this has been replaced with the better
three-argument form.