### PR TITLE
Update copyright year to that of current release

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author   = Jose Luis Martinez (jlmartinez@capside.com)
 abstract = Inflators to serialize data structures for DBIx::Class
 license  = Perl_5
 copyright_holder = Jose Luis Martinez
-copyright_year   = 2014
+copyright_year   = 2016
 
 version = 0.08
 


### PR DESCRIPTION
The current release is from 2016, however the copyright year in `dist.ini` was still set at 2014.  This brings the setting up to date.